### PR TITLE
fix(SystemUI):修复双排信号默认值为False

### DIFF
--- a/app/src/main/java/btm/m/os4/systemuihook/HookSettings.kt
+++ b/app/src/main/java/btm/m/os4/systemuihook/HookSettings.kt
@@ -245,7 +245,7 @@ data class HookSettings(
     val stackedMobileSignalRightMargin: Float = 0f,
     /** 0=do not hide, 1=hide non-data SIM, 2=hide all system signal icons. */
     val mobileSignalHideMode: Int = 0,
-    /** 0=hidden, 1=independent text. */
+    /** 0=system default, 1=independent text, 2=hidden. */
     val mobileNetworkTypeMode: Int = 0,
     /** 0=before signal, 1=after signal. */
     val mobileNetworkTypePosition: Int = 0,
@@ -927,9 +927,7 @@ private fun SharedPreferences.toSettings(): HookSettings {
     stackedMobileSignalRightMargin = getFloat(KEY_STACKED_MOBILE_SIGNAL_RIGHT_MARGIN, 0f)
         .coerceIn(-8f, 8f),
     mobileSignalHideMode = getInt(KEY_MOBILE_SIGNAL_HIDE_MODE, 0).coerceIn(0, 2),
-    // Values from the previous three-option menu (0=system default, 2=hidden)
-    // are both represented by the new hidden option.
-    mobileNetworkTypeMode = getInt(KEY_MOBILE_NETWORK_TYPE_MODE, 0).let { if (it == 1) 1 else 0 },
+    mobileNetworkTypeMode = getInt(KEY_MOBILE_NETWORK_TYPE_MODE, 0).coerceIn(0, 2),
     mobileNetworkTypePosition = getInt(KEY_MOBILE_NETWORK_TYPE_POSITION, 0).coerceIn(0, 1),
     mobileNetworkTypeDisplayLogic = getInt(KEY_MOBILE_NETWORK_TYPE_DISPLAY_LOGIC, 0).coerceIn(0, 1),
     mobileNetworkTypeCustomText = getString(KEY_MOBILE_NETWORK_TYPE_CUSTOM_TEXT, "")
@@ -1321,7 +1319,7 @@ private fun SharedPreferences.write(value: HookSettings) {
             value.stackedMobileSignalRightMargin.coerceIn(-8f, 8f),
         )
         .putInt(KEY_MOBILE_SIGNAL_HIDE_MODE, value.mobileSignalHideMode.coerceIn(0, 2))
-        .putInt(KEY_MOBILE_NETWORK_TYPE_MODE, value.mobileNetworkTypeMode.coerceIn(0, 1))
+        .putInt(KEY_MOBILE_NETWORK_TYPE_MODE, value.mobileNetworkTypeMode.coerceIn(0, 2))
         .putInt(KEY_MOBILE_NETWORK_TYPE_POSITION, value.mobileNetworkTypePosition.coerceIn(0, 1))
         .putInt(KEY_MOBILE_NETWORK_TYPE_DISPLAY_LOGIC, value.mobileNetworkTypeDisplayLogic.coerceIn(0, 1))
         .putString(KEY_MOBILE_NETWORK_TYPE_CUSTOM_TEXT, value.mobileNetworkTypeCustomText.take(128))

--- a/app/src/main/java/btm/m/os4/systemuihook/HyperSystemUiModule.kt
+++ b/app/src/main/java/btm/m/os4/systemuihook/HyperSystemUiModule.kt
@@ -718,11 +718,11 @@ class HyperSystemUiModule : XposedModule() {
                         view?.resources?.getResourceEntryName(view.id)
                     }.getOrNull()
                     val hideNetworkType = preferences.getBoolean(KEY_HIDE_STATUS_BAR_NETWORK_TYPE, false)
-                    // The old value 2 (hidden) and the new value 0 (hidden) have the
-                    // same behavior. Only value 1 enables the independent label.
+                    // 0 keeps SystemUI's original presentation, 1 replaces it with the
+                    // independent label, and 2 hides the network type completely.
                     val mobileNetworkTypeMode = preferences
                         .getInt(KEY_MOBILE_NETWORK_TYPE_MODE, 0)
-                        .let { if (it == 1) 1 else 0 }
+                        .coerceIn(0, 2)
                     val hideWifiStandard = preferences.getBoolean(KEY_HIDE_STATUS_BAR_WIFI_STANDARD, false)
                     val hideClockText = preferences.getBoolean(KEY_HIDE_STATUS_BAR_CLOCK_TEXT, false)
                     val hideNetworkActivity = preferences.getBoolean(KEY_HIDE_STATUS_BAR_NETWORK_ACTIVITY, false)
@@ -734,7 +734,7 @@ class HyperSystemUiModule : XposedModule() {
                         hideSecondaryMobileRoot || hideOriginalDualSignal ||
                         ((resourceName == "mobile_type" || resourceName == "mobile_type_single" ||
                             resourceName == "mobile_special_5G") &&
-                            (hideNetworkType || mobileNetworkTypeMode in 0..1) &&
+                            (hideNetworkType || mobileNetworkTypeMode != 0) &&
                             !(resourceName == "mobile_type_single" &&
                                 isIndependentMobileType && mobileNetworkTypeMode == 1)) ||
                             (resourceName == "wifi_standard" && hideWifiStandard) ||
@@ -1883,6 +1883,11 @@ class HyperSystemUiModule : XposedModule() {
     ) {
         stackedMobilePreferences = preferences
         val enabled = { preferences.getBoolean(KEY_STACKED_MOBILE_SIGNAL_ENABLED, false) }
+        val presentationRequired = {
+            enabled() ||
+                preferences.getInt(KEY_MOBILE_SIGNAL_HIDE_MODE, 0).coerceIn(0, 2) == 1 ||
+                preferences.getInt(KEY_MOBILE_NETWORK_TYPE_MODE, 0).coerceIn(0, 2) == 1
+        }
         var hookCount = 0
 
         runCatching {
@@ -1943,9 +1948,11 @@ class HyperSystemUiModule : XposedModule() {
                 .intercept { chain ->
                     val result = chain.proceed()
                     (chain.getArg(0) as? ViewGroup)?.let { root ->
-                        registerStackedMobilePresentation(root, enabled)
-                        captureMobileNetworkTypeSource(root, chain.getArg(2))
-                        refreshStackedMobilePresentations(enabled)
+                        if (presentationRequired()) {
+                            registerStackedMobilePresentation(root, enabled)
+                            captureMobileNetworkTypeSource(root, chain.getArg(2))
+                            refreshStackedMobilePresentations(enabled)
+                        }
                     }
                     result
                 }
@@ -1995,8 +2002,10 @@ class HyperSystemUiModule : XposedModule() {
                 .intercept { chain ->
                     val result = chain.proceed()
                     (result as? ViewGroup)?.let { root ->
-                        registerStackedMobilePresentation(root, enabled)
-                        refreshStackedMobilePresentations(enabled)
+                        if (presentationRequired()) {
+                            registerStackedMobilePresentation(root, enabled)
+                            refreshStackedMobilePresentations(enabled)
+                        }
                     }
                     result
                 }
@@ -2107,8 +2116,10 @@ class HyperSystemUiModule : XposedModule() {
                 .intercept { chain ->
                     val result = chain.proceed()
                     (chain.thisObject as? ViewGroup)?.let { root ->
-                        registerStackedMobilePresentation(root, enabled)
-                        refreshStackedMobilePresentations(enabled)
+                        if (presentationRequired()) {
+                            registerStackedMobilePresentation(root, enabled)
+                            refreshStackedMobilePresentations(enabled)
+                        }
                     }
                     result
                 }
@@ -2275,7 +2286,7 @@ class HyperSystemUiModule : XposedModule() {
         val group = presentation.mobileGroup ?: return
         val signalContainer = presentation.mobileSignalContainer
         val mode = stackedMobilePreferences?.getInt(KEY_MOBILE_NETWORK_TYPE_MODE, 0)
-            ?.let { if (it == 1) 1 else 0 } ?: 0
+            ?.coerceIn(0, 2) ?: 0
         val position = stackedMobilePreferences?.getInt(KEY_MOBILE_NETWORK_TYPE_POSITION, 0)?.coerceIn(0, 1) ?: 0
         val slotIndex = synchronized(stackedMobileSignalLock) {
             stackedMobileSubscriptions[presentation.subscriptionId]?.slot
@@ -2385,7 +2396,10 @@ class HyperSystemUiModule : XposedModule() {
                     if (shouldShow && displayText.isNotEmpty()) View.VISIBLE else View.GONE,
                 )
             }
-            else -> setStackedMobileViewVisibility(textView, View.GONE)
+            2 -> setStackedMobileViewVisibility(textView, View.GONE)
+            else -> if (textView.tag == INDEPENDENT_MOBILE_TYPE_TAG) {
+                setStackedMobileViewVisibility(textView, View.GONE)
+            }
         }
     }
 
@@ -2451,8 +2465,10 @@ class HyperSystemUiModule : XposedModule() {
             }
         }
         registerMobileNetworkStateCallback(root.context, enabled)
-        ensureIndependentMobileType(presentation)
-        ensureDualMobileSignal(presentation)
+        if (stackedMobilePreferences?.getInt(KEY_MOBILE_NETWORK_TYPE_MODE, 0) == 1) {
+            ensureIndependentMobileType(presentation)
+        }
+        if (enabled()) ensureDualMobileSignal(presentation)
         if (!presentation.attachListenerInstalled) {
             root.addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
                 override fun onViewAttachedToWindow(view: View) {
@@ -2610,7 +2626,7 @@ class HyperSystemUiModule : XposedModule() {
         applyIndependentMobileType(presentation, useStacked)
         if (!useStacked) {
             restoreSecondaryMobileRoot(presentation)
-            restoreDualMobileSignal(presentation)
+            if (presentation.dualContainer != null) restoreDualMobileSignal(presentation)
             return
         }
 

--- a/app/src/main/java/btm/m/os4/systemuihook/MainActivity.kt
+++ b/app/src/main/java/btm/m/os4/systemuihook/MainActivity.kt
@@ -3192,9 +3192,13 @@ OverlayDropdownPreference(
                     onSelectedIndexChange = { value -> update { it.copy(mobileSignalHideMode = value) } },
                 )
 OverlayDropdownPreference(
-                    title = tr("\u72ec\u7acb\u79fb\u52a8\u7f51\u7edc\u7c7b\u578b", "\u72ec\u7acb\u79fb\u52a8\u7f51\u7edc\u7c7b\u578b"),
-                    items = listOf(tr("\u4e0d\u663e\u793a", "\u4e0d\u663e\u793a"), tr("\u72ec\u7acb\u663e\u793a", "\u72ec\u7acb\u663e\u793a")),
-                    selectedIndex = s.mobileNetworkTypeMode.coerceIn(0, 1),
+                    title = tr("\u79fb\u52a8\u7f51\u7edc\u7c7b\u578b\u663e\u793a", "\u79fb\u52a8\u7f51\u7edc\u7c7b\u578b\u663e\u793a"),
+                    items = listOf(
+                        tr("\u8ddf\u968f\u7cfb\u7edf\u9ed8\u8ba4", "\u8ddf\u968f\u7cfb\u7edf\u9ed8\u8ba4"),
+                        tr("\u72ec\u7acb\u663e\u793a", "\u72ec\u7acb\u663e\u793a"),
+                        tr("\u4e0d\u663e\u793a", "\u4e0d\u663e\u793a"),
+                    ),
+                    selectedIndex = s.mobileNetworkTypeMode.coerceIn(0, 2),
                     onSelectedIndexChange = { value -> update { it.copy(mobileNetworkTypeMode = value) } },
                 )
                 AnimatedVisibility(visible = s.mobileNetworkTypeMode == 1) {


### PR DESCRIPTION
## 修复状态栏信号功能在默认配置下仍会生效的问题。
原因是移动网络类型默认值 0 被错误解释为“隐藏”，且判断条件 mobileNetworkTypeMode in 0..1 对所有合法值恒为真，导致系统网络类型默认被隐藏；同时信号展示对象也会在功能关闭时被创建。

已完成编译测试，验证通过。